### PR TITLE
Added config file for alan custom setup

### DIFF
--- a/alan_config/.gitignore
+++ b/alan_config/.gitignore
@@ -1,0 +1,1 @@
+config.json

--- a/alan_config/config.json
+++ b/alan_config/config.json
@@ -1,0 +1,7 @@
+{
+    "language": "english", 
+    "name": "Alan", 
+    "owner": "Cameron", 
+    "voice": "Moira", 
+    "wake_phrase": "wake up"
+}

--- a/alan_config/config.json
+++ b/alan_config/config.json
@@ -1,7 +1,7 @@
 {
-    "language": "english", 
+    "language": "spanish", 
     "name": "Alan", 
-    "owner": "Cameron", 
-    "voice": "Moira", 
+    "owner": "Jordan", 
+    "voice": "Jorge", 
     "wake_phrase": "wake up"
 }

--- a/alan_config/config.json
+++ b/alan_config/config.json
@@ -1,7 +1,7 @@
 {
-    "language": "spanish", 
+    "language": "english", 
     "name": "Alan", 
     "owner": "Jordan", 
-    "voice": "Jorge", 
+    "voice": "Alex", 
     "wake_phrase": "wake up"
 }

--- a/alan_config/config_utils.py
+++ b/alan_config/config_utils.py
@@ -1,0 +1,89 @@
+import gnureadline
+
+class AutoComplete(object):
+  """ Autofills when [tab] is pressed in terminal """
+
+  def __init__(self, options):
+    self.options = sorted(options)
+
+  def complete(self, text, state):
+    if state == 0: 
+      # on first trigger, build possible matches
+      if text:
+        self.matches = [s for s in self.options if s and s.startswith(text.lower())]
+      else: 
+        # no text entered, all matches possible
+        self.matches = self.options[:]
+
+      # return match indexed by state
+      try: 
+        return self.matches[state]
+      except IndexError:
+        return None
+
+
+class colors:
+  # Terminal colors for easy reading
+
+  HEADER = '\033[95m'
+  BLUE = '\033[94m'
+  GREEN = '\033[92m'
+  WARNING = '\033[93m'
+  FAIL = '\033[91m'
+  ENDC = '\033[0m'
+
+
+""" Helper Methods """
+
+def output_message(color, text):
+  # Format output text with color
+
+  return color + "{}".format(text) + colors.ENDC
+
+def welcome(ALAN_LOGO):
+  # Welcome prompt
+
+  print output_message(colors.GREEN, "Welcome to the Alan CLI installer!\n\n{}".format(ALAN_LOGO)) 
+
+
+def get_owner():
+  # Prompts the user for their name
+
+  owner = raw_input(output_message(colors.GREEN, "Before we begin, what should I call you?    "))
+  print output_message(colors.BLUE, "\nNice to meet you, {}\n".format(owner))
+  return owner
+
+
+def get_name():
+  # Prompts the user for the name of the bot
+
+  bot = raw_input(output_message(colors.GREEN, "What would you like to call me?    "))
+  print output_message(colors.GREEN, "\nGreat! I'll answer to " + colors.BLUE + "{}".format(bot) + colors.GREEN + " from now on.\n\n")
+  return bot
+
+
+def get_language(data):
+  # Prompts the use for the speaking language
+
+  print output_message(colors.WARNING, "What language is easiest to understand?\n")
+  completer = AutoComplete([key for key in data])
+  gnureadline.set_completer(completer.complete)
+  gnureadline.parse_and_bind('tab: complete')
+  language = raw_input(output_message(colors.WARNING, "[Press Tab] >>> "))
+  return language
+
+
+def get_voice(languages_and_voices, language):
+  # Prompts the user for the voice of the bot
+
+  voices = zip(languages_and_voices[language])
+  known_voices = [key[0].lower() for key in voices]
+  string_voices = " ".join(languages_and_voices[language])
+
+  # Prompt
+  print output_message(colors.WARNING, "\nPlease select my voice: \n{}\n".format(string_voices))
+  voice_completer = AutoComplete(known_voices)
+  gnureadline.set_completer(voice_completer.complete)
+  gnureadline.parse_and_bind('tab: complete')
+  voice = raw_input(output_message(colors.WARNING, "[Press Tab] >>> "))
+  return voice

--- a/alan_config/init.py
+++ b/alan_config/init.py
@@ -51,7 +51,5 @@ if __name__ in '__main__':
     "wake_phrase": "wake up"
   }
 
-
-
   with open("config.json", "w") as config:
     json.dump(alan_json, config, sort_keys = True, indent = 4, ensure_ascii=False)

--- a/alan_config/init.py
+++ b/alan_config/init.py
@@ -64,7 +64,6 @@ if __name__ in '__main__':
   dict_voices = zip(data[language])
   known_voices = sorted([key[0].lower() for key in dict_voices])
   string_voices = " ".join(data[language])
-  print(known_voices)
   print(colors.WARNING + "\nPlease select my voice: \n{}\n".format(string_voices))
   voice_completer = MyCompleter(known_voices)
   gnureadline.set_completer(voice_completer.complete)

--- a/alan_config/init.py
+++ b/alan_config/init.py
@@ -1,39 +1,10 @@
 import json
-import gnureadline
+from os import system
 
-class colors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
+from config_utils import *
 
-class MyCompleter(object):  # Custom completer
 
-  def __init__(self, options):
-    self.options = sorted(options)
-
-  def complete(self, text, state):
-    if state == 0:  # on first trigger, build possible matches
-      if text:  # cache matches (entries that start with entered text)
-        self.matches = [s for s in self.options 
-                          if s and s.startswith(text.lower())]
-      else:  # no text entered, all matches possible
-        self.matches = self.options[:]
-
-      # return match indexed by state
-      try: 
-        return self.matches[state]
-      except IndexError:
-        return None
-
-with open('voices.json') as f:
-  data = json.load(f)
-
-alan_logo = str(
+ALAN_LOGO = str(
 "           _               ____        _    \n"
 "     /\   | |             |  _ \      | |   \n"
 "    /  \  | | __ _ _ __   | |_) | ___ | |_  \n"
@@ -42,39 +13,36 @@ alan_logo = str(
 " /_/    \_\_|\__,_|_| |_| |____/ \___/ \__| \n"
 "                                            \n")
 if __name__ in '__main__':
-  print colors.OKGREEN + "Welcome to the Alan CLI installer!\n\n{}".format(alan_logo)
+
+  
+  with open('voices.json') as f:
+    # Open available languages/voices file
+    languages_and_voices = json.load(f)
+
+  # Welcome prompt
+  welcome(ALAN_LOGO)
   
   # Prompt for Owner
-  owner = raw_input("Before we begin, what should I call you?    " + colors.ENDC)
-  print(colors.OKBLUE + "\nNice to meet you, {}\n".format(owner))
-  
-  # Prompt for Name
-  bot = raw_input(colors.OKGREEN + "What would you like to call me?    " + colors.ENDC)
-  print(colors.OKGREEN + "\nGreat! I'll answer to " + colors.OKBLUE + "{}".format(bot) + colors.OKGREEN + " from now on.\n\n" + colors.ENDC)
+  owner = get_owner()
 
+  # Prompt for Bot Name
+  bot = get_name()
+   
   # Prompt for Language
-  print(colors.WARNING + "What language is easiest to understand?\n")
-  known_languages = sorted([key for key in data])
-  completer = MyCompleter(known_languages)
-  gnureadline.set_completer(completer.complete)
-  gnureadline.parse_and_bind('tab: complete')
-  language = raw_input("[Press Tab] >>> " + colors.ENDC)
- 
-  # Get available voices 
-  dict_voices = zip(data[language])
-  known_voices = sorted([key[0].lower() for key in dict_voices])
-  string_voices = " ".join(data[language])
-  print(known_voices)
-  print(colors.WARNING + "\nPlease select my voice: \n{}\n".format(string_voices))
-  voice_completer = MyCompleter(known_voices)
-  gnureadline.set_completer(voice_completer.complete)
-  gnureadline.parse_and_bind('tab: complete')
-  voice = raw_input("[Press Tab] >>> " + colors.ENDC)
-  
-  print colors.HEADER + \
-    "\nHere is what I have: \n\n  " + \
-    "Your Name: {}\n  My Name: {}\n  Language: {}\n  Voice: {}\n\n".format(owner.title(), bot.title(), language.title(), voice.title()) + colors.ENDC
+  language = get_language(languages_and_voices)
 
+  # Get available voices
+  voice = get_voice(languages_and_voices, language)
+
+  confirmation_message = "\nHere is what I have: \n\n" + \
+    " - Your Name: {}\n".format(owner.title()) + \
+    " - My Name: {}\n".format(bot.title()) + \
+    " - Language: {}\n".format(language.title()) + \
+    " - Voice: {}\n\n".format(voice.title())
+
+  print colors.HEADER + confirmation_message + colors.ENDC
+  system('say -v "{}" "{}"'.format(voice.title(), confirmation_message))
+  
   alan_json = {
     "owner": owner,
     "name": bot,
@@ -82,6 +50,8 @@ if __name__ in '__main__':
     "language": language,
     "wake_phrase": "wake up"
   }
+
+
 
   with open("config.json", "w") as config:
     json.dump(alan_json, config, sort_keys = True, indent = 4, ensure_ascii=False)

--- a/alan_config/init.py
+++ b/alan_config/init.py
@@ -1,0 +1,87 @@
+import json
+import gnureadline
+
+class colors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+class MyCompleter(object):  # Custom completer
+
+  def __init__(self, options):
+    self.options = sorted(options)
+
+  def complete(self, text, state):
+    if state == 0:  # on first trigger, build possible matches
+      if text:  # cache matches (entries that start with entered text)
+        self.matches = [s for s in self.options 
+                          if s and s.startswith(text.lower())]
+      else:  # no text entered, all matches possible
+        self.matches = self.options[:]
+
+      # return match indexed by state
+      try: 
+        return self.matches[state]
+      except IndexError:
+        return None
+
+with open('voices.json') as f:
+  data = json.load(f)
+
+alan_logo = str(
+"           _               ____        _    \n"
+"     /\   | |             |  _ \      | |   \n"
+"    /  \  | | __ _ _ __   | |_) | ___ | |_  \n"
+"   / /\ \ | |/ _` | '_ \  |  _ < / _ \| __| \n"
+"  / ____ \| | (_| | | | | | |_) | (_) | |_  \n"
+" /_/    \_\_|\__,_|_| |_| |____/ \___/ \__| \n"
+"                                            \n")
+if __name__ in '__main__':
+  print colors.OKGREEN + "Welcome to the Alan CLI installer!\n\n{}".format(alan_logo)
+  
+  # Prompt for Owner
+  owner = raw_input("Before we begin, what should I call you?    " + colors.ENDC)
+  print(colors.OKBLUE + "\nNice to meet you, {}\n".format(owner))
+  
+  # Prompt for Name
+  bot = raw_input(colors.OKGREEN + "What would you like to call me?    " + colors.ENDC)
+  print(colors.OKGREEN + "\nGreat! I'll answer to " + colors.OKBLUE + "{}".format(bot) + colors.OKGREEN + " from now on.\n\n" + colors.ENDC)
+
+  # Prompt for Language
+  print(colors.WARNING + "What language is easiest to understand?\n")
+  known_languages = sorted([key for key in data])
+  completer = MyCompleter(known_languages)
+  gnureadline.set_completer(completer.complete)
+  gnureadline.parse_and_bind('tab: complete')
+  language = raw_input("[Press Tab] >>> " + colors.ENDC)
+ 
+  # Get available voices 
+  dict_voices = zip(data[language])
+  known_voices = sorted([key[0].lower() for key in dict_voices])
+  string_voices = " ".join(data[language])
+  print(known_voices)
+  print(colors.WARNING + "\nPlease select my voice: \n{}\n".format(string_voices))
+  voice_completer = MyCompleter(known_voices)
+  gnureadline.set_completer(voice_completer.complete)
+  gnureadline.parse_and_bind('tab: complete')
+  voice = raw_input("[Press Tab] >>> " + colors.ENDC)
+  
+  print colors.HEADER + \
+    "\nHere is what I have: \n\n  " + \
+    "Your Name: {}\n  My Name: {}\n  Language: {}\n  Voice: {}\n\n".format(owner.title(), bot.title(), language.title(), voice.title()) + colors.ENDC
+
+  alan_json = {
+    "owner": owner,
+    "name": bot,
+    "voice": voice.title(),
+    "language": language,
+    "wake_phrase": "wake up"
+  }
+
+  with open("config.json", "w") as config:
+    json.dump(alan_json, config, sort_keys = True, indent = 4, ensure_ascii=False)

--- a/alan_config/voices.json
+++ b/alan_config/voices.json
@@ -1,0 +1,33 @@
+{
+  "english": [
+    "Alex", "Fred", "Samantha", "Victoria",
+    "Daniel", "Fiona", "Moira", "Tessa",
+    "Veena", "Karen"
+  ],
+  "italian": ["Alice","Luca"],
+  "swedish": ["Alva"],
+  "french": ["Amelie","Thomas"],
+  "german": ["Anna"],
+  "hebrew": ["Carmit"],
+  "indonesian": ["Damayanti"],
+  "spanish": ["Diego", "Jorge", "Juan", "Monica", "Paulina"],
+  "dutch": ["Ellen"],
+  "romanian": ["Ioana"],
+  "portuguese": ["Joana", "Luciana"],
+  "thai": ["Kanya"],
+  "japanese": ["Kyoko"],
+  "slovak": ["Laura"],
+  "hindi": ["Lekha"],
+  "arabic": ["Maged"],
+  "hungarian": ["Mariska"],
+  "greek": ["Melina"],
+  "russian": ["Milena", "Yuri"],
+  "danish": ["Sara"],
+  "finnish": ["Satu"],
+  "chinese": ["Mei-Jia", "Sin-ji", "Ting-Ting"],
+  "nl": ["Xander"],
+  "turkish": ["Yelda"],
+  "korean": ["Yuna"],
+  "polish": ["Zosia"],
+  "czech": ["Zuzana"]
+}


### PR DESCRIPTION
Setup a configuration file that currently asks the following:

  - Owner (User's) name
  - Bot name
  - Language choice (OSX)
  - Voice selection (OSX)

Currently writes to `config.json` file - nothing implemented in core Alan yet.